### PR TITLE
Update libigl submodule

### DIFF
--- a/include/visualize_aabbtree.h
+++ b/include/visualize_aabbtree.h
@@ -132,7 +132,7 @@ inline void visualize_aabbtree(
   v.data().set_face_based(true);
   v.data().set_colors(Eigen::RowVector3d(146,197,222)/255.);
   v.data().set_edges(EVB,EEB,Eigen::RowVector3d(5,113,176)/255.);
-  v.core.background_color.setConstant(0.8);
+  v.core(0).background_color.setConstant(0.8);
   v.launch();
 }
 


### PR DESCRIPTION
Please see discussion [here](https://github.com/alecjacobson/computer-graphics-bounding-volume-hierarchy/issues/56)

Eigen moved from bitbucket to gitlab so the one of the files related to cmake had a broken link. This changed was made sometime in December of 2019 so I decided to pin the libigl sub module to v2.2.0.

This ended up breaking one of the header files. So I've updated a function call to fix that